### PR TITLE
Add product management and enhance wishlist sharing

### DIFF
--- a/src/main/java/com/Kodebutikken/wishlist/controller/ProductController.java
+++ b/src/main/java/com/Kodebutikken/wishlist/controller/ProductController.java
@@ -5,11 +5,9 @@ import com.Kodebutikken.wishlist.service.ProductService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/products")
@@ -20,6 +18,16 @@ public class ProductController {
         this.productService = productService;
     }
 
+    @GetMapping()
+    public String showProducts(HttpSession session, Model model) {
+        if (session.getAttribute("profileId") == null) {
+            return "redirect:/profile/login";
+        }
+        List<Product> products = productService.getProductsByProfileId((Long) session.getAttribute("profileId"));
+        model.addAttribute("products", products);
+        return "product/products";
+    }
+
     @GetMapping("/create")
     public String showCreateProductForm(HttpSession session,
                                         @RequestParam(required = false) Long redirectWishlistId,
@@ -27,10 +35,22 @@ public class ProductController {
         if (session.getAttribute("profileId") == null) {
             return "redirect:/profile/login";
         }
-
         model.addAttribute("product", new Product());
         model.addAttribute("redirectWishlistId", redirectWishlistId);
         return "product/create";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteProduct(@PathVariable Long id, HttpSession session) {
+        if (session.getAttribute("profileId") == null) {
+            return "redirect:/profile/login";
+        }
+        Product product = productService.getProductById(id);
+        if (product == null || !productService.getProfileIdFromProduct(id).equals(session.getAttribute("profileId"))) {
+            return "redirect:/products";
+        }
+        productService.deleteProduct(id);
+        return "redirect:/products";
     }
 
     @PostMapping("/create")
@@ -40,13 +60,10 @@ public class ProductController {
         if (session.getAttribute("profileId") == null) {
             return "redirect:/profile/login";
         }
-
-        productService.createProduct(product);
-
+        productService.createProduct(product, (Long) session.getAttribute("profileId"));
         if (redirectWishlistId != null) {
             return "redirect:/wishlists/" + redirectWishlistId + "/wish/add";
         }
-
         return "redirect:/wishlists";
     }
 }

--- a/src/main/java/com/Kodebutikken/wishlist/controller/ProfileController.java
+++ b/src/main/java/com/Kodebutikken/wishlist/controller/ProfileController.java
@@ -18,7 +18,7 @@ public class ProfileController {
 
     @GetMapping("/login")
     public String showLogin(HttpSession session) {
-        if(session.getAttribute("profileId") != null) {
+        if (session.getAttribute("profileId") != null) {
             return "redirect:/wishlist/wishlists";
         }
         return "auth/login";
@@ -32,7 +32,7 @@ public class ProfileController {
 
     @GetMapping("/register")
     public String showRegister(HttpSession session, Model model) {
-        if(session.getAttribute("profileId") != null) {
+        if (session.getAttribute("profileId") != null) {
             return "redirect:/wishlist/wishlists";
         }
         Profile profile = new Profile();
@@ -41,6 +41,17 @@ public class ProfileController {
         model.addAttribute("email", profile.getEmail());
         model.addAttribute("password", profile.getPassword());
         return "auth/register";
+    }
+
+    @GetMapping()
+    public String showProfile(HttpSession session, Model model) {
+        if (session.getAttribute("profileId") == null) {
+            return "redirect:/profile/login";
+        }
+        Long profileId = (Long) session.getAttribute("profileId");
+        Profile profile = profileService.getProfileById(profileId);
+        model.addAttribute("profile", profile);
+        return "profile/profile";
     }
 
     @GetMapping("/update")

--- a/src/main/java/com/Kodebutikken/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/Kodebutikken/wishlist/controller/WishlistController.java
@@ -143,16 +143,17 @@ public class WishlistController {
         return "redirect:/wishlists/" + wishlistId;
     }
 
-    @GetMapping("/{wishlistId}/share")
-    public String shareWishlist(@PathVariable Long wishlistId, HttpSession session, Model model) {
+    @GetMapping("/{id}/share")
+    public String shareWishlist(@PathVariable Long id, HttpSession session, Model model) {
         if (session.getAttribute("profileId") == null) {
             return "redirect:/profile/login";
         }
-        Wishlist wishlist = wishlistService.getWishlistById(wishlistId);
+        Wishlist wishlist = wishlistService.getWishlistById(id);
         if (wishlist == null || !wishlist.getProfileId().equals(session.getAttribute("profileId"))) {
             return "redirect:/wishlists";
         }
+        wishlistService.shareWishlist(id, Visibility.PUBLIC);
         model.addAttribute("wishlist", wishlist);
-        return "wishlist/share";
+        return "profile/wishlist";
     }
 }

--- a/src/main/java/com/Kodebutikken/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/Kodebutikken/wishlist/controller/WishlistController.java
@@ -97,8 +97,12 @@ public class WishlistController {
         if (session.getAttribute("profileId") == null) {
             return "redirect:/profile/login";
         }
-        model.addAttribute("wishlist", wishlistService.getWishlistById(id));
-        return "wishlist/edit"; // Return the view name for editing a wishlist
+        Wishlist wishlist = wishlistService.getWishlistById(id);
+        if (wishlist == null || !wishlist.getProfileId().equals(session.getAttribute("profileId"))) {
+            return "redirect:/wishlists";
+        }
+        model.addAttribute("wishlist", wishlist);
+        return "update"; // Return the view name for editing a wishlist
     }
 
     @PostMapping("/edit")
@@ -116,7 +120,7 @@ public class WishlistController {
             return "redirect:/profile/login";
         }
         model.addAttribute("wishlistId", wishlistId);
-        model.addAttribute("products", productService.getAllProducts());
+        model.addAttribute("products", productService.getProductsByProfileId((Long) session.getAttribute("profileId")));
         return "wishlist/addWish";
     }
 
@@ -127,6 +131,10 @@ public class WishlistController {
                                        HttpSession session) {
         if (session.getAttribute("profileId") == null) {
             return "redirect:/profile/login";
+        }
+        Wishlist wishlist = wishlistService.getWishlistById(wishlistId);
+        if (wishlist == null || !wishlist.getProfileId().equals(session.getAttribute("profileId"))) {
+            return "redirect:/wishlists";
         }
         wishlistService.addProductToWishlist(wishlistId, productId, quantity);
         return "redirect:/wishlists/" + wishlistId;

--- a/src/main/java/com/Kodebutikken/wishlist/repository/ProductRepository.java
+++ b/src/main/java/com/Kodebutikken/wishlist/repository/ProductRepository.java
@@ -33,12 +33,28 @@ public class ProductRepository {
         return jdbcTemplate.queryForObject(sql, productRowMapper, id);
     }
 
-    public void createProduct(Product product) {
-        String sql = "INSERT INTO product (name, price, description, product_url) VALUES (?, ?, ?, ?)";
+    public Long getProfileIdFromProductId(Long id) {
+        String sql = "SELECT profile_id FROM product WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, Long.class, id);
+    }
+
+    public void createProduct(Product product, Long profileId) {
+        String sql = "INSERT INTO product (name, price, description, product_url, profile_id) VALUES (?, ?, ?, ?, ?)";
         jdbcTemplate.update(sql,
                 product.getName(),
                 product.getPrice(),
                 product.getDescription(),
-                product.getProductUrl());
+                product.getProductUrl(),
+                profileId);
+    }
+
+    public List<Product> getProductsByProfileId(Long id) {
+        String sql = "SELECT * FROM product WHERE profile_id = ?";
+        return jdbcTemplate.query(sql, productRowMapper, id);
+    }
+
+    public void deleteProduct(Long id) {
+        String sql = "DELETE FROM product WHERE id = ?";
+        jdbcTemplate.update(sql, id);
     }
 }

--- a/src/main/java/com/Kodebutikken/wishlist/service/ProductService.java
+++ b/src/main/java/com/Kodebutikken/wishlist/service/ProductService.java
@@ -22,7 +22,19 @@ public class ProductService {
         return productRepository.getProductById(id);
     }
 
-    public void createProduct(Product product) {
-        productRepository.createProduct(product);
+    public Long getProfileIdFromProduct(Long id) {
+        return productRepository.getProfileIdFromProductId(id);
+    }
+
+    public List<Product> getProductsByProfileId(Long id) {
+        return productRepository.getProductsByProfileId(id);
+    }
+
+    public void createProduct(Product product, Long profileId) {
+        productRepository.createProduct(product, profileId);
+    }
+
+    public void deleteProduct(Long id) {
+        productRepository.deleteProduct(id);
     }
 }

--- a/src/main/java/com/Kodebutikken/wishlist/service/WishlistService.java
+++ b/src/main/java/com/Kodebutikken/wishlist/service/WishlistService.java
@@ -2,6 +2,7 @@ package com.Kodebutikken.wishlist.service;
 
 
 import com.Kodebutikken.wishlist.exception.WishlistNotFoundException;
+import com.Kodebutikken.wishlist.model.Visibility;
 import com.Kodebutikken.wishlist.model.Wishlist;
 import com.Kodebutikken.wishlist.repository.WishlistRepository;
 import org.springframework.stereotype.Service;
@@ -42,5 +43,13 @@ public class WishlistService {
 
     public void removeProductFromWishlist(Long wishlistId, Long productId) {
         wishlistRepository.removeProductFromWishlist(wishlistId, productId);
+    }
+
+    public void shareWishlist(Long id, Visibility visibility) {
+        Wishlist wishlist = wishlistRepository.getWishlistById(id);
+        if (wishlist == null) {
+            throw new WishlistNotFoundException("Ønskeliste med id " + id + " blev ikke fundet");
+        }
+        wishlistRepository.updateWishlistVisibility(id, visibility);
     }
 }

--- a/src/main/resources/mysql/schema.sql
+++ b/src/main/resources/mysql/schema.sql
@@ -20,7 +20,9 @@ CREATE TABLE product
     name        VARCHAR(255) NOT NULL,
     price       FLOAT        NOT NULL,
     description TEXT,
-    product_url VARCHAR(255)
+    product_url VARCHAR(255),
+    profile_id  BIGINT       NOT NULL,
+    FOREIGN KEY (profile_id) REFERENCES profile (id) ON DELETE CASCADE
 );
 
 CREATE TABLE wishlist
@@ -31,7 +33,7 @@ CREATE TABLE wishlist
     due_date   DATE,
     visibility VARCHAR(20)  NOT NULL,
     profile_id BIGINT       NOT NULL,
-    FOREIGN KEY (profile_id) REFERENCES profile (id)
+    FOREIGN KEY (profile_id) REFERENCES profile (id) ON DELETE CASCADE
 );
 
 CREATE TABLE wishlist_item
@@ -41,5 +43,5 @@ CREATE TABLE wishlist_item
     quantity    INT NOT NULL,
     PRIMARY KEY (wishlist_id, product_id),
     FOREIGN KEY (wishlist_id) REFERENCES wishlist (id) ON DELETE CASCADE,
-    FOREIGN KEY (product_id) REFERENCES product (id)
+    FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE
 );

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -312,6 +312,7 @@ a {
     text-decoration: none;
 }
 
+.products-header,
 .Wishlists-header {
     display: flex;
     justify-content: space-between;

--- a/src/main/resources/templates/fragments/fragments.html
+++ b/src/main/resources/templates/fragments/fragments.html
@@ -13,6 +13,7 @@
         <ul class="navbar-menu">
             <li><a th:href="@{/}">Hjem</a></li>
             <li><a th:href="@{/wishlists}">Ønskelister</a></li>
+            <li><a th:href="@{/products}">Produkter</a></li>
         </ul>
 
         <div class="navbar-actions">

--- a/src/main/resources/templates/product/products.html
+++ b/src/main/resources/templates/product/products.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dine produkter</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" th:href="@{/styles.css}">
+    <link rel="icon" type="image/x-icon" th:href="@{/favicon.ico}">
+</head>
+<body>
+<nav th:replace="~{fragments/fragments :: navbar}"></nav>
+<main class="container">
+    <div class="products-header">
+        <h1>Dine produkter</h1>
+        <a th:href="@{/products/create}">
+            <button class="btn-link-primary" type="button">Opret nyt produkt</button>
+        </a>
+    </div>
+    <section class="gift-list-section">
+        <div class="gift-list">
+            <article th:if="${!products.isEmpty()}" th:each="product : ${products}" class="product-item">
+                <div class="product-item-top">
+                    <div>
+                        <h2 th:text="${product.name}">Gave Navn</h2>
+                        <p class="product-price" th:text="${product.price} + ' DKK'">Pris: 0 DKK</p>
+                    </div>
+                </div>
+
+                <p class="product-description"
+                   th:text="${product.description != null and !#strings.isEmpty(product.description)} ? ${product.description} : 'Ingen beskrivelse tilføjet endnu.'">
+                    Beskrivelse: Ingen beskrivelse
+                </p>
+
+                <div class="product-actions">
+                    <a th:if="${product.productUrl != null and !#strings.isEmpty(product.productUrl)}"
+                       th:href="${product.productUrl}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="product-link">Gå til produkt</a>
+                    <span th:if="${product.productUrl == null or #strings.isEmpty(product.productUrl)}"
+                          class="product-link-disabled">Produktlink mangler</span>
+                    <a th:href="@{/products/delete/{id}(id=${product.id})}" class="btn-link-destructive delete-button">Slet produkt</a>
+                </div>
+            </article>
+
+            <div th:if="${products.isEmpty()}" class="no-gifts">
+                <p>Du har ikke oprettet nogle produkter endnu.</p>
+            </div>
+        </div>
+    </section>
+</main>
+<footer th:replace="~{fragments/fragments :: footer}"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/profile/profile.html
+++ b/src/main/resources/templates/profile/profile.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="da">
+<head>
+    <meta charset="UTF-8">
+    <title>Din profil</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" th:href="@{/styles.css}">
+    <link rel="icon" type="image/x-icon" th:href="@{/favicon.ico}">
+</head>
+<body>
+<nav th:replace="~{fragments/fragments :: navbar}"></nav>
+<main class="container profile-page">
+    <section class="profile-hero">
+        <div class="profile-hero-content">
+            <div class="container-heading">
+                <h1>Din profil</h1>
+                <p>Her kan du se dine profiloplysninger</p>
+            </div>
+            <div class="card">
+                <p>Brugernavn: <span th:text="${profile.userName}"></span></p>
+                <p>Email: <span th:text="${profile.email}"></span></p>
+            </div>
+            <div class="button-row-10 justify-center">
+                <a th:href="@{/profile/update}">
+                    <button type="button" class="btn-link-primary">Opdater profil</button>
+                </a>
+            </div>
+        </div>
+    </section>
+</main>
+<footer th:replace="~{fragments/fragments :: footer}"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/wishlist/create.html
+++ b/src/main/resources/templates/wishlist/create.html
@@ -18,23 +18,28 @@
 
             <input type="hidden" id="profileId" th:field="*{profileId}" th:value="${profileId}"/>
 
-        <div class="form-group">
-            <label for="name">Navn på ønskeliste:</label>
-            <input type="text" id="name" th:field="*{name}" required>
-        </div>
-        <div class="form-group">
-            <label for="eventDate">Dato for begivenhed:</label>
-            <input type="date" id="eventDate" th:field="*{dueDate}" required>
-        </div>
-        <div class="form-group">
-            <label for="visibility">Synlighed:</label>
-            <select id="visibility" th:field="*{visibility}" required>
-                <option th:each="visibilityOption : ${visibilityOptions}"
-                        th:value="${visibilityOption}"
-                        th:text="${visibilityOption.displayName}">
-                </option>
-            </select>
-        </div>
+            <div class="form-group">
+                <label for="name">Navn på ønskeliste: *</label>
+                <input type="text" id="name" th:field="*{name}" required>
+            </div>
+            <div class="form-group">
+                <label for="imageUrl">Billede-URL:</label>
+                <input type="url" id="imageUrl" th:field="*{imageUrl}" placeholder="https://example.com/image.jpg">
+                <small>Indsæt et link til et billede, da filupload ikke understøttes.</small>
+            </div>
+            <div class="form-group">
+                <label for="eventDate">Dato for begivenhed: *</label>
+                <input type="date" id="eventDate" th:field="*{dueDate}" required>
+            </div>
+            <div class="form-group">
+                <label for="visibility">Synlighed: *</label>
+                <select id="visibility" th:field="*{visibility}" required>
+                    <option th:each="visibilityOptions : ${visibilityOptions}"
+                            th:value="${visibilityOptions}"
+                            th:text="${visibilityOptions.displayName}">
+                    </option>
+                </select>
+            </div>
 
             <div class="form-group">
                 <button class="btn-link-primary" type="submit">Opret ønskeliste</button>


### PR DESCRIPTION
### Description

This pull request introduces the following updates:

- **Product Management**:
  - Added the ability to display, create, and delete products associated with user profiles.
  - Integrated `profileId` into `Product` for user-specific management.
  - Updated the database schema to include a foreign key for `profileId` and enable cascading deletes.
  - Introduced a new `products.html` page and added a "Produkter" link to the navbar.
  - Enhanced `ProductService`, `ProductRepository`, and related controllers to manage product operations.
  - Improved UI styling with updates to Thymeleaf templates and CSS.

- **Wishlist Sharing**:
  - Renamed `wishlistId` to `id` in the `shareWishlist` endpoint for consistency.
  - Updated the sharing functionality to redirect to a profile-specific view.
  - Implemented logic to make wishlists publicly visible when shared.
  - Introduced `shareWishlist` in `WishlistService` and updated `WishlistRepository` to support visibility changes.

These changes also include improvements to security and validation for `profileId` when dealing with wishlists and products, along with enhancements to the consistency of the UI and functionality flow.